### PR TITLE
increase timers limits

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -45,6 +45,9 @@ http {
 
     lua_package_path "/etc/nginx/libs/?.lua;;";
 
+    lua_max_pending_timers 16384; # maximum number of waiting tasks
+    lua_max_running_timers 4096; # maximum number of simultaneous running tasks
+
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
         '$status $body_bytes_sent "$http_referer" '
         '"$http_user_agent" $upstream_response_time '


### PR DESCRIPTION
We were running out of timers context:

```
2022/06/22 16:30:00 [alert] 48#48: lua failed to run timer with function defined at @/etc/nginx/libs/skynet/scanner.lua:3: 256 lua_max_running_timers are not enough
```

Increasing the number of timers should be an easy way to resolve this temporarily at least.