### PR TITLE
custom 401 for subdomain hns and skylink endpoints

### DIFF
--- a/nginx/conf.d/include/error-pages
+++ b/nginx/conf.d/include/error-pages
@@ -1,0 +1,5 @@
+error_page 401 /401.html;
+location = /401.html {
+    root /etc/nginx/conf.d/pages;
+    internal;
+}

--- a/nginx/conf.d/server/server.api
+++ b/nginx/conf.d/server/server.api
@@ -2,6 +2,7 @@ listen 443 ssl http2;
 
 include /etc/nginx/conf.d/include/ssl-settings;
 include /etc/nginx/conf.d/include/init-optional-variables;
+include /etc/nginx/conf.d/include/error-pages;
 
 # ddos protection: closing slow connections
 client_body_timeout 1h;
@@ -22,12 +23,6 @@ rewrite ^/portals /skynet/portals permanent;
 rewrite ^/stats /skynet/stats permanent;
 rewrite ^/skynet/blacklist /skynet/blocklist permanent;
 rewrite ^/docs(?:/(.*))?$ https://sdk.skynetlabs.com/$1 permanent;
-
-error_page 401 /401.html;
-location = /401.html {
-    root /etc/nginx/conf.d/pages;
-    internal;
-}
 
 location / {
     include /etc/nginx/conf.d/include/cors;

--- a/nginx/conf.d/server/server.hns
+++ b/nginx/conf.d/server/server.hns
@@ -2,6 +2,7 @@ listen 443 ssl http2;
 
 include /etc/nginx/conf.d/include/ssl-settings;
 include /etc/nginx/conf.d/include/init-optional-variables;
+include /etc/nginx/conf.d/include/error-pages;
 
 location / {
     set_by_lua_block $hns_domain { return string.match(ngx.var.host, "[^%.]+") }

--- a/nginx/conf.d/server/server.skylink
+++ b/nginx/conf.d/server/server.skylink
@@ -2,6 +2,7 @@ listen 443 ssl http2;
 
 include /etc/nginx/conf.d/include/ssl-settings;
 include /etc/nginx/conf.d/include/init-optional-variables;
+include /etc/nginx/conf.d/include/error-pages;
 
 location / {
     set_by_lua_block $skylink { return string.match(ngx.var.host, "%w+") }


### PR DESCRIPTION
custom 401 page was only defined on base /<endpoints> server, this pull request adds it to both 
- `<hns domain>.hns.<portal domain>.<tld>`
-  `<skylink>.<portal domain>.<tld>`

Tested on https://siasky.xyz (check with me if it's still deployed there if it doesn't work when verifying):
- https://siasky.xyz/dAAkyrC0cyDk-Fdpb-6SHCEFQdPJoiiuCM69Ds0fklPPZQ (working before)
- https://1009qt4r72qibuv49rtf4p6o78thu8umbgeihbt8jm2362708pdhb0g.siasky.xyz/ (was not working, works now)
- https://note-to-self.hns.siasky.xyz/ (was not working, works now)