### PR TITLE
adjust anon limits to account service defaults

### DIFF
--- a/nginx/libs/skynet/account.lua
+++ b/nginx/libs/skynet/account.lua
@@ -11,8 +11,8 @@ local tier_id_free = 1
 local anon_limits = {
     ["tierID"] = tier_id_anonymous,
     ["tierName"] = "anonymous",
-    ["upload"] = 655360,
-    ["download"] = 655360,
+    ["upload"] = 5242880,
+    ["download"] = 5242880,
     ["maxUploadSize"] = 1073741824,
     ["registry"] = 250
 }


### PR DESCRIPTION
adjust broken limits to account defaults from https://github.com/SkynetLabs/skynet-accounts/blob/74d66237b011c6d8b31b9d09eda3035e9c400c81/database/user.go#L56-L64

```json
{
  "tierName": "anonymous",
  "upload": 5242880,
  "download": 5242880,
  "maxUploadSize": 1073741824,
  "registry": 250
}
```