### PR TITLE
fix application/javascript mime type

### DIFF
--- a/nginx/conf.d/gzip.conf
+++ b/nginx/conf.d/gzip.conf
@@ -15,4 +15,4 @@ gzip_min_length 256;
 gzip_proxied expired no-cache no-store private auth;
 
 # enables the types of files that can be compressed	
-gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon;
+gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon;


### PR DESCRIPTION
fix application/javascript mime type to enable gzip compression (still leave text/javascript on since some js files have this mime type)

source: https://github.com/nginx/nginx/commit/3086ab2996403fbb4cf6525986e00e4a521ada1e

application/javascript: https://siasky.net/PAMFI3Ie_Nm04jHyBKLp2vubpeefZFvELbqF_ZCzUETP_w
application/javascript: https://siasky.net/PANVbAf4mNxgU4zcQSp4G5v3-hyxnvP4nGLwQeA1uqW1FA