### PR TITLE
do not ratelimit internal traffic

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -110,10 +110,13 @@ http {
         ngx.header["Skynet-Server-Api"] = ngx.var.scheme .. "://" .. ngx.var.skynet_server_domain
     }
 
-    # ratelimit specified IPs
+    # do not rate limit local traffic (ie. health checks)
     geo $limit {
-        default 0;
-        include /etc/nginx/conf.d/include/ratelimited;
+        default 1;
+        127.0.0.0/8 0; # host network
+        10.0.0.0/8 0; # private network
+        172.16.0.0/12 0; # private network
+        192.168.0.0/16 0; # private network
     }
 
     map $limit $limit_key {
@@ -121,16 +124,10 @@ http {
         1 $binary_remote_addr;
     }
 
-    limit_req_zone $binary_remote_addr zone=uploads_by_ip:10m rate=10r/s;
-    limit_req_zone $limit_key zone=uploads_by_ip_throttled:10m rate=10r/m;
-
-    limit_req_zone $binary_remote_addr zone=registry_access_by_ip:10m rate=60r/m;
-    limit_req_zone $limit_key zone=registry_access_by_ip_throttled:10m rate=20r/m;
-
-    limit_conn_zone $binary_remote_addr zone=upload_conn:10m;
-    limit_conn_zone $limit_key zone=upload_conn_rl:10m;
-
-    limit_conn_zone $binary_remote_addr zone=downloads_by_ip:10m;
+    limit_req_zone $limit_key zone=uploads_by_ip:10m rate=10r/s;
+    limit_req_zone $limit_key zone=registry_access_by_ip:10m rate=60r/m;
+    limit_conn_zone $limit_key zone=upload_conn_limit:10m;
+    limit_conn_zone $limit_key zone=download_conn_limit:10m;
 
     limit_req_status 429;
     limit_conn_status 429;

--- a/nginx/conf.d/include/location-skylink
+++ b/nginx/conf.d/include/location-skylink
@@ -1,6 +1,6 @@
 include /etc/nginx/conf.d/include/cors;
 
-limit_conn downloads_by_ip 100; # ddos protection: max 100 downloads at a time
+limit_conn download_conn_limit 100; # ddos protection: max 100 downloads at a time
 
 # ensure that skylink that we pass around is base64 encoded (transform base32 encoded ones)
 # this is important because we want only one format in cache keys and logs

--- a/nginx/conf.d/include/location-skynet-registry
+++ b/nginx/conf.d/include/location-skynet-registry
@@ -2,7 +2,6 @@ include /etc/nginx/conf.d/include/cors;
 include /etc/nginx/conf.d/include/sia-auth;
 
 limit_req zone=registry_access_by_ip burst=600 nodelay;
-limit_req zone=registry_access_by_ip_throttled burst=200 nodelay;
 
 proxy_set_header User-Agent: Sia-Agent;
 proxy_read_timeout 600; # siad should timeout with 404 after 5 minutes

--- a/nginx/conf.d/server/server.api
+++ b/nginx/conf.d/server/server.api
@@ -211,10 +211,7 @@ location /skynet/skyfile {
     include /etc/nginx/conf.d/include/portal-access-check;
 
     limit_req zone=uploads_by_ip burst=10 nodelay;
-    limit_req zone=uploads_by_ip_throttled;
-
-    limit_conn upload_conn 5;
-    limit_conn upload_conn_rl 1;
+    limit_conn upload_conn_limit 5;
 
     client_max_body_size 5000M; # make sure to limit the size of upload to a sane value
 
@@ -262,10 +259,8 @@ location /skynet/tus {
     include /etc/nginx/conf.d/include/cors-headers; # include cors headers but do not overwrite OPTIONS response
 
     limit_req zone=uploads_by_ip burst=10 nodelay;
-    limit_req zone=uploads_by_ip_throttled;
 
-    limit_conn upload_conn 5;
-    limit_conn upload_conn_rl 1;
+    limit_conn upload_conn_limit 5;
 
     # Do not limit body size in nginx, skyd will reject early on too large upload
     client_max_body_size 0;
@@ -362,10 +357,8 @@ location /skynet/pin {
     include /etc/nginx/conf.d/include/portal-access-check;
 
     limit_req zone=uploads_by_ip burst=10 nodelay;
-    limit_req zone=uploads_by_ip_throttled;
 
-    limit_conn upload_conn 5;
-    limit_conn upload_conn_rl 1;
+    limit_conn upload_conn_limit 5;
 
     proxy_set_header User-Agent: Sia-Agent;
     proxy_pass http://sia:9980$uri?siapath=$dir1/$dir2/$dir3&$args;
@@ -443,7 +436,7 @@ location ~ "^/file/(([a-zA-Z0-9-_]{46}|[a-z0-9]{55})(/.*)?)$" {
 location /skynet/trustless/basesector {
     include /etc/nginx/conf.d/include/cors;
 
-    limit_conn downloads_by_ip 100; # ddos protection: max 100 downloads at a time
+    limit_conn download_conn_limit 100; # ddos protection: max 100 downloads at a time
 
     # default download rate to unlimited
     set $limit_rate 0;


### PR DESCRIPTION
- removes rate limit (both number of parallel connections and requests over time) from internal traffic (coming from local subnets)
- removes unused throttled rate limits - we have not used them in over a year now with current limits setup now

tested on dev2 by running 7 critical checks at once that failed with 429s before and succeeded when running this branch

closes https://github.com/SkynetLabs/webportal-nginx/issues/31