### PR TITLE
set limits to anon on portals without accounts

### DIFF
--- a/nginx/conf.d/include/location-skylink
+++ b/nginx/conf.d/include/location-skylink
@@ -27,13 +27,13 @@ access_by_lua_block {
         if skynet_account.is_access_forbidden() then
             return skynet_account.exit_access_forbidden()
         end
-
-        -- get account limits of currently authenticated user
-        local limits = skynet_account.get_account_limits()
-
-        -- apply download speed limit
-        ngx.var.limit_rate = limits.download
     end
+
+    -- get account limits of currently authenticated user
+    local limits = skynet_account.get_account_limits()
+
+    -- apply download speed limit
+    ngx.var.limit_rate = limits.download
 }
 
 limit_rate_after 512k;

--- a/nginx/conf.d/include/location-skynet-registry
+++ b/nginx/conf.d/include/location-skynet-registry
@@ -25,13 +25,13 @@ access_by_lua_block {
         if skynet_account.is_access_forbidden() then
             return skynet_account.exit_access_forbidden()
         end
+    end
 
-        -- get account limits of currently authenticated user
-        local limits = skynet_account.get_account_limits()
-        
-        -- apply registry rate limits (forced delay)
-        if limits.registry > 0 then
-            ngx.sleep(limits.registry / 1000)
-        end
+    -- get account limits of currently authenticated user
+    local limits = skynet_account.get_account_limits()
+    
+    -- apply registry rate limits (forced delay)
+    if limits.registry > 0 then
+        ngx.sleep(limits.registry / 1000)
     end
 }

--- a/nginx/conf.d/server/server.api
+++ b/nginx/conf.d/server/server.api
@@ -187,14 +187,14 @@ location /skynet/registry/subscription {
             if skynet_account.is_access_forbidden() then
                 return skynet_account.exit_access_forbidden()
             end
-
-            -- get account limits of currently authenticated user
-            local limits = skynet_account.get_account_limits()
-
-            -- apply bandwidth limit and notification delay
-            ngx.var.bandwidthlimit = limits.download
-            ngx.var.notificationdelay = limits.registry
         end
+
+        -- get account limits of currently authenticated user
+        local limits = skynet_account.get_account_limits()
+
+        -- apply bandwidth limit and notification delay
+        ngx.var.bandwidthlimit = limits.download
+        ngx.var.notificationdelay = limits.registry
     }
 
     proxy_set_header User-Agent: Sia-Agent;
@@ -299,13 +299,13 @@ location /skynet/tus {
             if skynet_account.is_access_forbidden() then
                 return skynet_account.exit_access_forbidden()
             end
-
-            -- get account limits of currently authenticated user
-            local limits = skynet_account.get_account_limits()
-
-            -- apply upload size limits
-            ngx.req.set_header("SkynetMaxUploadSize", limits.maxUploadSize)
         end
+
+        -- get account limits of currently authenticated user
+        local limits = skynet_account.get_account_limits()
+
+        -- apply upload size limits
+        ngx.req.set_header("SkynetMaxUploadSize", limits.maxUploadSize)
     }
 
     # extract skylink from base64 encoded upload metadata and assign to a proper header
@@ -466,13 +466,13 @@ location /skynet/trustless/basesector {
             if skynet_account.is_access_forbidden() then
                 return skynet_account.exit_access_forbidden()
             end
-
-            -- get account limits of currently authenticated user
-            local limits = skynet_account.get_account_limits()
-
-            -- apply download speed limit
-            ngx.var.limit_rate = limits.download
         end
+
+        -- get account limits of currently authenticated user
+        local limits = skynet_account.get_account_limits()
+
+        -- apply download speed limit
+        ngx.var.limit_rate = limits.download
     }
 
     limit_rate_after 512k;

--- a/nginx/libs/skynet/account.lua
+++ b/nginx/libs/skynet/account.lua
@@ -81,8 +81,8 @@ function _M.get_account_limits()
     local utils = require('utils')
     local auth_headers = _M.get_auth_headers()
 
-    -- simple case of anonymous request - none of available auth headers exist
-    if utils.is_table_empty(auth_headers) then
+    -- simple case of anonymous request - none of available auth headers exist or accounts are not enabled
+    if utils.is_table_empty(auth_headers) or _M.accounts_disabled() then
         return anon_limits
     end
 


### PR DESCRIPTION
currently when running portal with disabled accounts (like siasky.net) users would get no limits and broken tus uploads

this pull request changes the limits for users on portal without accounts to what would be anonymous user on portal with accounts and also fixes broken tus uploads